### PR TITLE
Fixing the download procedure for mercurial.

### DIFF
--- a/src/agner_download.erl
+++ b/src/agner_download.erl
@@ -42,7 +42,7 @@ fetch_1({hg, URL, Rev}, Directory) ->
         false -> %% new
             PortClone = hg(["clone", "-U", URL, Directory]),
             process_port(PortClone, fun () -> 
-                                            PortUpdate = hg(["update", Rev]),
+                                            PortUpdate = hg(["update", Rev], [{cd, Directory}]),
                                             process_port(PortUpdate, fun () -> ok end)
                                     end);
         true -> %% existing


### PR DESCRIPTION
The current version first pulls with -U and then updates to the given revision. The problem with this approach is that hg requires to be in the repo to do it. This adds arguments to the port process to switch directories in between commands in order to update successfully
